### PR TITLE
Extract TemplateComponent CSS and add shadow stylesheet helper

### DIFF
--- a/scripts/style-utils.js
+++ b/scripts/style-utils.js
@@ -1,0 +1,26 @@
+export function attachShadowStylesheet(shadowRoot, href, { preload = true } = {}) {
+  if (!shadowRoot || !href) return;
+
+  if (preload && document?.head) {
+    const existingPreload = document.head.querySelector(
+      `link[rel="preload"][href="${href}"]`
+    );
+    if (!existingPreload) {
+      const preloadLink = document.createElement("link");
+      preloadLink.rel = "preload";
+      preloadLink.as = "style";
+      preloadLink.href = href;
+      document.head.appendChild(preloadLink);
+    }
+  }
+
+  const existingLink = shadowRoot.querySelector(
+    `link[rel="stylesheet"][href="${href}"]`
+  );
+  if (existingLink) return;
+
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = href;
+  shadowRoot.appendChild(link);
+}

--- a/webcomponents/TemplateComponent.css
+++ b/webcomponents/TemplateComponent.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/webcomponents/TemplateComponent.js
+++ b/webcomponents/TemplateComponent.js
@@ -1,24 +1,5 @@
 import { handleThemeChange } from "/scripts/theme.js";
-
-const CSS = `
-:host {
-  display: block;
-}
-`;
-
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 
 class TemplateComponent extends HTMLElement {
   constructor() {
@@ -26,13 +7,10 @@ class TemplateComponent extends HTMLElement {
     const sr = this.attachShadow({
       mode: "open",
     });
-    if (canAdopt && sharedSheet) {
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./TemplateComponent.css", import.meta.url).href
+    );
     // this.setAttribute("data-theme", getTheme()); 
     document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));
   }


### PR DESCRIPTION
### Motivation
- Reduce inline JS-defined CSS and allow components to load styles from external files by default to simplify maintenance and improve caching.
- Provide a small reusable helper to preload and attach stylesheets to shadow roots so multiple components can adopt the same pattern.

### Description
- Added `scripts/style-utils.js` which exports `attachShadowStylesheet(shadowRoot, href, { preload })`, a helper that preloads and appends a `link rel="stylesheet"` into a shadow root.
- Created `webcomponents/TemplateComponent.css` containing the TemplateComponent styles and removed the JS-inlined CSS from `webcomponents/TemplateComponent.js`.
- Updated `webcomponents/TemplateComponent.js` to import and call `attachShadowStylesheet` with `new URL("./TemplateComponent.css", import.meta.url).href` and retained the existing theme event handling.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a9e1b4a4832b961fbe313fcc503a)