### PR TITLE
Migrate web component styles to external CSS files and use shadow stylesheet helper

### DIFF
--- a/scripts/style-utils.js
+++ b/scripts/style-utils.js
@@ -1,0 +1,26 @@
+export function attachShadowStylesheet(shadowRoot, href, { preload = true } = {}) {
+  if (!shadowRoot || !href) return;
+
+  if (preload && document?.head) {
+    const existingPreload = document.head.querySelector(
+      `link[rel="preload"][href="${href}"]`
+    );
+    if (!existingPreload) {
+      const preloadLink = document.createElement("link");
+      preloadLink.rel = "preload";
+      preloadLink.as = "style";
+      preloadLink.href = href;
+      document.head.appendChild(preloadLink);
+    }
+  }
+
+  const existingLink = shadowRoot.querySelector(
+    `link[rel="stylesheet"][href="${href}"]`
+  );
+  if (existingLink) return;
+
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = href;
+  shadowRoot.appendChild(link);
+}

--- a/webcomponents/ArchivedListComponent/ArchivedListComponent.css
+++ b/webcomponents/ArchivedListComponent/ArchivedListComponent.css
@@ -1,0 +1,46 @@
+:host {
+  display: block;
+  --title-font: "Lucida Bright", "Palatino Linotype", "Book Antiqua", Palatino, "Times New Roman", Times, Georgia, serif;
+}
+.sidebar {
+  max-width: 400px;
+  padding: 20px;
+  background-color: #f4f4f4;
+  line-height: 160%;
+  border-radius: 10px;
+}
+h2 {
+  border-bottom: 1px solid;
+}
+#archive-list {
+  margin-top: 20px;
+}
+.archive-category > ul {
+  list-style: none;
+  margin: 0;
+}
+h2,
+h3 {
+  margin: 0;
+  font-family: var(--title-font);
+}
+a {
+  padding: 4px 8px;
+  color: black;
+  font-family: consolas, "Menlo", "Monaco", "Courier New", monospace;
+  text-decoration: none;
+  border-radius: 4px;
+}
+a:hover,
+a:focus {
+  color: #ff6600;
+  text-decoration: underline;
+}
+a:visited {
+  color: #7744aa;
+}
+@media (max-width: 992px) {
+  .article-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/webcomponents/ArchivedListComponent/ArchivedListComponent.js
+++ b/webcomponents/ArchivedListComponent/ArchivedListComponent.js
@@ -1,65 +1,4 @@
-const CSS = `
-:host {
-  display: block;
-  --title-font: "Lucida Bright", "Palatino Linotype", "Book Antiqua", Palatino, "Times New Roman", Times, Georgia, serif;
-}
-.sidebar {
-  max-width: 400px;
-  padding: 20px;
-  background-color: #f4f4f4;
-  line-height: 160%;
-  border-radius: 10px;
-}
-h2 {
-  border-bottom: 1px solid;
-}
-#archive-list {
-  margin-top: 20px;
-}
-.archive-category > ul {
-  list-style: none;
-  margin: 0;
-}
-h2,
-h3 {
-  margin: 0;
-  font-family: var(--title-font);
-}
-a {
-  padding: 4px 8px;
-  color: black;
-  font-family: consolas, "Menlo", "Monaco", "Courier New", monospace;
-  text-decoration: none;
-  border-radius: 4px;
-}
-a:hover,
-a:focus {
-  color: #ff6600;
-  text-decoration: underline;
-}
-a:visited {
-  color: #7744aa;
-}
-@media (max-width: 992px) {
-  .article-list {
-    grid-template-columns: 1fr;
-  }
-}
-`;
-
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 
 class CustomArchivedList extends HTMLElement {
   constructor() {
@@ -67,13 +6,10 @@ class CustomArchivedList extends HTMLElement {
     const sr = this.attachShadow({
       mode: "open",
     });
-    if (canAdopt && sharedSheet) {
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./ArchivedListComponent.css", import.meta.url).href
+    );
     // TODO
     // document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));
   }
@@ -81,16 +17,6 @@ class CustomArchivedList extends HTMLElement {
   connectedCallback() {
     this.render();
     initArchiveList(this); // Pass 'this' to use it inside initArchiveList
-  }
-
-  loadStyles() {
-    const styles = document.createElement("link");
-    styles.setAttribute("rel", "stylesheet");
-    styles.setAttribute(
-      "href",
-      "/webcomponents/ArchivedListComponent/ArchivedListComponent.css"
-    );
-    this.shadowRoot.appendChild(styles);
   }
 
   renderArchiveList(elementId, data) {

--- a/webcomponents/ArticleComponent/ArticleComponent.css
+++ b/webcomponents/ArticleComponent/ArticleComponent.css
@@ -1,0 +1,48 @@
+:host {
+  display: block;
+}
+#article {
+  padding: 10px 20px;
+}
+#article a {
+  color: #000;
+  text-decoration: none;
+}
+#article a:hover {
+  text-decoration: underline var(--text-color);
+}
+#footer {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 1em;
+}
+h4,
+h6 {
+  margin: 0;
+  font-family: var(--title-font);
+}
+h4 {
+  color: var(--text-color);
+  font-size: 1.5em;
+}
+h6 {
+  color: grey;
+  font-size: 1.2em;
+}
+p {
+  margin: 0;
+  margin-top: 0.5em;
+  color: var(--text-color);
+  font-size: 1em;
+}
+@media (max-width: 768px) {
+  h4 {
+    font-size: 1.25em;
+  }
+  h6 {
+    font-size: 0.875em;
+  }
+}

--- a/webcomponents/ArticleComponent/ArticleComponent.js
+++ b/webcomponents/ArticleComponent/ArticleComponent.js
@@ -1,69 +1,5 @@
 import { handleThemeChange } from "/scripts/theme.js";
-
-const CSS = `
-:host {
-  display: block;
-}
-#article {
-  padding: 10px 20px;
-}
-#article a {
-  color: #000;
-  text-decoration: none;
-}
-#article a:hover {
-  text-decoration: underline var(--text-color);
-}
-#footer {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 1em;
-}
-h4,
-h6 {
-  margin: 0;
-  font-family: var(--title-font);
-}
-h4 {
-  color: var(--text-color);
-  font-size: 1.5em;
-}
-h6 {
-  color: grey;
-  font-size: 1.2em;
-}
-p {
-  margin: 0;
-  margin-top: 0.5em;
-  color: var(--text-color);
-  font-size: 1em;
-}
-@media (max-width: 768px) {
-  h4 {
-    font-size: 1.25em;
-  }
-  h6 {
-    font-size: 0.875em;
-  }
-}
-`;
-
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 
 class ArticleList extends HTMLElement {
   constructor() {
@@ -71,13 +7,10 @@ class ArticleList extends HTMLElement {
     const sr = this.attachShadow({
       mode: "open",
     });
-    if (canAdopt && sharedSheet) {
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./ArticleComponent.css", import.meta.url).href
+    );
     // this.setAttribute("data-theme", getTheme());
     document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));
   }

--- a/webcomponents/CodeSnippetComponent/CodeSnippetComponent.css
+++ b/webcomponents/CodeSnippetComponent/CodeSnippetComponent.css
@@ -1,0 +1,114 @@
+:host {
+  display: block;
+  --code-font: consolas, "Menlo", "Monaco", "Courier New", monospace;
+  --code-font-size: 1em;
+  --code-line-height: 125%;
+}
+.snippet-container {
+  position: relative;
+  border: 1px solid var(--border-color);
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+.snippet-header {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  padding: 5px;
+  gap: 5px;
+  color: var(--text-color);
+  border-bottom: 1px solid var(--border-color);
+  user-select: none;
+}
+.btn-wrapper {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+.snippet-content {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  min-height: 1em;
+  background-color: var(--code-bg-color);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: auto;
+}
+.line-numbers {
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  left: 0;
+  padding: 0 5px;
+  color: var(--text-color);
+  background-color: var(--content-bg-color);
+  border-right: 1px solid var(--border-color);
+  user-select: none;
+  /* match the <pre> rendering context exactly */
+  white-space: pre;
+  display: block;
+  font-family: var(--code-font);
+  font-size: var(--code-font-size, 1em);
+  line-height: var(--code-line-height, 125%);
+  margin: 0;
+}
+.line-numbers span {
+  display: block;
+  height: auto;
+  line-height: var(--code-line-height, 125%);
+}
+::slotted(pre),
+pre {
+  margin: 0;
+  padding: 0 5px !important;
+  color: var(--code-color);
+  font-family: var(--code-font);
+  font-size: var(--code-font-size, 1em);
+  line-height: var(--code-line-height, 125%);
+}
+#result {
+  padding: 5px;
+}
+.text {
+  color: var(--text-color);
+  font-family: var(--code-font);
+  font-size: var(--code-font-size, 1em);
+  line-height: var(--code-line-height, 125%);
+}
+.string {
+  color: var(--code-str-color);
+}
+.symbol {
+  color: var(--text-color);
+}
+.comment,
+.comment .keyword {
+  color: var(--code-comment-color);
+  font-style: italic;
+}
+.keyword {
+  color: var(--code-kw-color);
+}
+/* HTML and CSS support */
+.attribute {
+  color: #9cdcfe;
+}
+.css-prop {
+  color: var(--code-css-prop-color);
+}
+.css-val {
+  color: var(--code-css-val-color);
+}
+button {
+  margin-left: 5px;
+  cursor: pointer;
+}
+label,
+input[type="checkbox"] {
+  font-size: 0.8em;
+  cursor: pointer;
+}

--- a/webcomponents/CodeSnippetComponent/CodeSnippetComponent.js
+++ b/webcomponents/CodeSnippetComponent/CodeSnippetComponent.js
@@ -1,149 +1,16 @@
 import { handleThemeChange } from "/scripts/theme.js";
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 import "/webcomponents/ChipComponent/ChipComponent.js";
-
-const CSS = `
-:host {
-  display: block;
-  --code-font: consolas, "Menlo", "Monaco", "Courier New", monospace;
-  --code-font-size: 1em;
-  --code-line-height: 125%;
-}
-.snippet-container {
-  position: relative;
-  border: 1px solid var(--border-color);
-  -webkit-text-size-adjust: 100%;
-  text-size-adjust: 100%;
-}
-.snippet-header {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  padding: 5px;
-  gap: 5px;
-  color: var(--text-color);
-  border-bottom: 1px solid var(--border-color);
-  user-select: none;
-}
-.btn-wrapper {
-  flex: 1;
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-.snippet-content {
-  position: relative;
-  display: flex;
-  align-items: flex-start;
-  min-height: 1em;
-  background-color: var(--code-bg-color);
-  overflow-x: auto;
-  -webkit-overflow-scrolling: auto;
-}
-.line-numbers {
-  position: sticky;
-  position: -webkit-sticky;
-  top: 0;
-  left: 0;
-  padding: 0 5px;
-  color: var(--text-color);
-  background-color: var(--content-bg-color);
-  border-right: 1px solid var(--border-color);
-  user-select: none;
-  /* match the <pre> rendering context exactly */
-  white-space: pre;
-  display: block;
-  font-family: var(--code-font);
-  font-size: var(--code-font-size, 1em);
-  line-height: var(--code-line-height, 125%);
-  margin: 0;
-}
-.line-numbers span {
-  display: block;
-  height: auto;
-  line-height: var(--code-line-height, 125%);
-}
-::slotted(pre),
-pre {
-  margin: 0;
-  padding: 0 5px !important;
-  color: var(--code-color);
-  font-family: var(--code-font);
-  font-size: var(--code-font-size, 1em);
-  line-height: var(--code-line-height, 125%);
-}
-#result {
-  padding: 5px;
-}
-.text {
-  color: var(--text-color);
-  font-family: var(--code-font);
-  font-size: var(--code-font-size, 1em);
-  line-height: var(--code-line-height, 125%);
-}
-.string {
-  color: var(--code-str-color);
-}
-.symbol {
-  color: var(--text-color);
-}
-.comment,
-.comment .keyword {
-  color: var(--code-comment-color);
-  font-style: italic;
-}
-.keyword {
-  color: var(--code-kw-color);
-}
-/* HTML and CSS support */
-.attribute {
-  color: #9cdcfe;
-}
-.css-prop {
-  color: var(--code-css-prop-color);
-}
-.css-val {
-  color: var(--code-css-val-color);
-}
-button {
-  margin-left: 5px;
-  cursor: pointer;
-}
-label,
-input[type="checkbox"] {
-  font-size: 0.8em;
-  cursor: pointer;
-}
-`;
-
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
 class CodeSnippet extends HTMLElement {
   constructor() {
     super();
     const sr = this.attachShadow({
       mode: "open",
     });
-    if (canAdopt && sharedSheet) {
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./CodeSnippetComponent.css", import.meta.url).href
+    );
     document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));
   }
 

--- a/webcomponents/DateComponent/DateComponent.css
+++ b/webcomponents/DateComponent/DateComponent.css
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+}
+time {
+  display: flex;
+  flex-direction: column;
+  color: var(--text-color);
+  font-style: italic;
+}

--- a/webcomponents/DateComponent/DateComponent.js
+++ b/webcomponents/DateComponent/DateComponent.js
@@ -1,31 +1,6 @@
 import { fetchData } from "/scripts/fetchData.js";
 import { handleThemeChange } from "/scripts/theme.js";
-
-const CSS = `
-:host {
-  display: block;
-}
-time {
-  display: flex;
-  flex-direction: column;
-  color: var(--text-color);
-  font-style: italic;
-}
-`;
-
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 
 class CustomDate extends HTMLElement {
   constructor() {
@@ -33,13 +8,10 @@ class CustomDate extends HTMLElement {
     const sr = this.attachShadow({
       mode: "open",
     });
-    if (canAdopt && sharedSheet) {
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./DateComponent.css", import.meta.url).href
+    );
     document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));
   }
 

--- a/webcomponents/FooterComponent/FooterComponent.css
+++ b/webcomponents/FooterComponent/FooterComponent.css
@@ -1,0 +1,29 @@
+:host {
+  display: block;
+}
+ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin: 0;
+  padding: 10px;
+  list-style: none;
+}
+a {
+  padding: 4px 8px;
+  color: var(--link-color);
+  font-family: consolas, "Menlo", "Monaco", "Courier New", monospace;
+  text-decoration: none;
+  border-radius: 4px;
+  transition: color 0.3s, background-color 0.3s;
+}
+a:hover,
+a:focus {
+  color: #ff6600;
+  text-decoration: none;
+  background-color: #f2f2f2;
+}
+a:visited {
+  color: var(--link-visited-color);
+}

--- a/webcomponents/FooterComponent/FooterComponent.js
+++ b/webcomponents/FooterComponent/FooterComponent.js
@@ -1,49 +1,5 @@
 import { getTheme, handleThemeChange } from "/scripts/theme.js";
-
-const CSS = `
-:host {
-  display: block;
-}
-ul {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 10px;
-  margin: 0;
-  padding: 10px;
-  list-style: none;
-}
-a {
-  padding: 4px 8px;
-  color: var(--link-color);
-  font-family: consolas, "Menlo", "Monaco", "Courier New", monospace;
-  text-decoration: none;
-  border-radius: 4px;
-  transition: color 0.3s, background-color 0.3s;
-}
-a:hover,
-a:focus {
-  color: #ff6600;
-  text-decoration: none;
-  background-color: #f2f2f2;
-}
-a:visited {
-  color: var(--link-visited-color);
-}
-`;
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 
 class CustomFooter extends HTMLElement {
   constructor() {
@@ -51,13 +7,10 @@ class CustomFooter extends HTMLElement {
     const sr = this.attachShadow({
       mode: "open",
     });
-    if (canAdopt && sharedSheet) {
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./FooterComponent.css", import.meta.url).href
+    );
     this.setAttribute("data-theme", getTheme()); // for iOS 15
     document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));
   }

--- a/webcomponents/HeaderComponent/HeaderComponent.css
+++ b/webcomponents/HeaderComponent/HeaderComponent.css
@@ -1,0 +1,98 @@
+:host {
+  display: block;
+  --header-height: 60px;
+  background: var(--header-bg-color, white);
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1em;
+  padding: 0 1em;
+  height: var(--header-height);
+}
+#logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+#links ul {
+  display: flex;
+  gap: 1em;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+#links ul > li {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+#logo > a,
+#links a {
+  color: var(--text-color);
+  text-decoration: none;
+}
+#logo > a:hover,
+#links a:hover {
+  text-decoration: underline;
+}
+#menu-toggle {
+  display: none;
+}
+.menu-icon {
+  display: none;
+  width: 30px;
+  height: 24px;
+  flex-shrink: 0;
+  cursor: pointer;
+  position: relative;
+}
+.menu-icon span,
+.menu-icon span::before,
+.menu-icon span::after {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 3px;
+  background: var(--text-color);
+  border-radius: 2px;
+  position: absolute;
+}
+.menu-icon span::before {
+  top: 8px;
+}
+.menu-icon span::after {
+  top: 16px;
+}
+.nav-menu {
+  display: flex;
+  gap: 1em;
+}
+@media (max-width: 768px) {
+  header h1 {
+    display: none;
+  } /* hide title */
+  .menu-icon {
+    display: block;
+  }
+  .nav-menu {
+    display: none;
+    position: absolute;
+    top: var(--header-height);
+    right: 0;
+    background: var(--bg-color, white);
+    flex-direction: column;
+    padding: 1em;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+  #menu-toggle:checked ~ .nav-menu {
+    display: flex;
+  }
+  #menu-toggle:checked ~ .nav-menu ul {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+  }
+}

--- a/webcomponents/HeaderComponent/HeaderComponent.js
+++ b/webcomponents/HeaderComponent/HeaderComponent.js
@@ -3,126 +3,18 @@ import {
   getTheme,
   handleThemeChange,
 } from "../../scripts/theme.js";
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 import "../LogoComponent.js";
 import "../ToggleComponent/ToggleComponent.js";
-
-const CSS = `
-  :host {
-    display: block;
-    --header-height: 60px;
-    background: var(--header-bg-color, white);
-  }
-  header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1em;
-    padding: 0 1em;
-    height: var(--header-height);
-  }
-  #logo {
-    display: flex;
-    align-items: center;
-    gap: 0.5em;
-  }
-  #links ul {
-    display: flex;
-    gap: 1em;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-  #links ul > li {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-  #logo > a,
-  #links a {
-    color: var(--text-color);
-    text-decoration: none;
-  }
-  #logo > a:hover,
-  #links a:hover {
-    text-decoration: underline;
-  }
-  #menu-toggle { display: none; }
-  .menu-icon {
-    display: none;
-    width: 30px;
-    height: 24px;
-    flex-shrink: 0;
-    cursor: pointer;
-    position: relative;
-  }
-  .menu-icon span,
-  .menu-icon span::before,
-  .menu-icon span::after {
-    content: "";
-    display: block;
-    width: 100%;
-    height: 3px;
-    background: var(--text-color);
-    border-radius: 2px;
-    position: absolute;
-  }
-  .menu-icon span::before { top: 8px; }
-  .menu-icon span::after  { top: 16px; }
-  .nav-menu { display: flex; gap: 1em; }
-  @media (max-width: 768px) {
-    header h1 { display: none; } /* hide title */
-    .menu-icon { display: block; }
-    .nav-menu {
-      display: none;
-      position: absolute;
-      top: var(--header-height);
-      right: 0;
-      background: var(--bg-color, white);
-      flex-direction: column;
-      padding: 1em;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    }
-    #menu-toggle:checked ~ .nav-menu {
-      display: flex;
-    }
-    #menu-toggle:checked ~ .nav-menu ul {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: flex-start;
-    }
-  }
-`;
-
-// Constructable Stylesheet supported?
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-// adoptedStyleSheets supported?
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
 
 class CustomHeader extends HTMLElement {
   constructor() {
     super();
     const sr = this.attachShadow({ mode: "open" });
-    if (canAdopt && sharedSheet) {
-      // Modern browsers (Chrome, Firefox, Safari 16.4+, iOS 16.4+)
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      // Fallback for iOS 15 and older: inject a <style> tag
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./HeaderComponent.css", import.meta.url).href
+    );
     // this.setAttribute("data-theme", getTheme()); // for iOS 15
     document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));
   }

--- a/webcomponents/LogoComponent.css
+++ b/webcomponents/LogoComponent.css
@@ -1,0 +1,58 @@
+:host {
+  display: block;
+  --logo-color: rgb(121, 0, 142);
+  opacity: 1;
+  transition: opacity 0.5s;
+}
+.square {
+  background-color: var(--bg-color, white);
+  border: var(--logo-border-width, 9.6px) solid var(--logo-color);
+  border-radius: var(--logo-border-radius, 6.4px);
+}
+.outline {
+  position: relative;
+  width: var(--length, 240px);
+  height: var(--length, 240px);
+  overflow: hidden;
+}
+.left-square,
+.right-square,
+.core {
+  position: absolute;
+}
+.left-square {
+  top: calc(var(--length) * 0.3);
+  left: calc(0px - var(--length) / 3);
+  width: var(--logo-left-square-width);
+  height: var(--logo-left-square-width);
+  z-index: 100;
+  transform: rotateZ(60deg);
+}
+.right-square {
+  top: calc(var(--length) * (1 / 15));
+  left: calc(var(--length) * (11 / 15));
+  width: var(--logo-right-square-width);
+  height: var(--logo-right-square-width);
+  z-index: 50;
+  transform: rotateZ(60deg);
+}
+.core {
+  position: relative;
+  width: var(--logo-core-width);
+  height: var(--logo-core-width);
+  top: calc(var(--logo-core-width) - var(--logo-border-width) / 2);
+  margin: auto;
+  border: var(--logo-border-width) solid var(--text-color, black);
+}
+:host(.animated) .left-square,
+:host(.animated) .right-square {
+  animation: transformLeft 4s infinite linear;
+}
+@keyframes transformLeft {
+  from {
+    transform: translateX(calc(-1.467 * var(--length))) rotateZ(60deg);
+  }
+  to {
+    transform: translateX(calc(1.733 * var(--length))) rotateZ(-300deg);
+  }
+}

--- a/webcomponents/LogoComponent.js
+++ b/webcomponents/LogoComponent.js
@@ -1,77 +1,5 @@
 import { getTheme, handleThemeChange } from "/scripts/theme.js";
-
-const CSS = `
-:host {
-  display: block;
-  --logo-color: rgb(121, 0, 142);
-  opacity: 1;
-  transition: opacity 0.5s;
-}
-.square {
-  background-color: var(--bg-color, white);
-  border: var(--logo-border-width, 9.6px) solid var(--logo-color);
-  border-radius: var(--logo-border-radius, 6.4px);
-}
-.outline {
-  position: relative;
-  width: var(--length, 240px);
-  height: var(--length, 240px);
-  overflow: hidden;
-}
-.left-square, .right-square, .core {
-  position: absolute;
-}
-.left-square {
-  top: calc(var(--length) * 0.3);
-  left: calc(0px - var(--length) / 3);
-  width: var(--logo-left-square-width);
-  height: var(--logo-left-square-width);
-  z-index: 100;
-  transform: rotateZ(60deg);
-}
-.right-square {
-  top: calc(var(--length) * (1 / 15));
-  left: calc(var(--length) * (11 / 15));
-  width: var(--logo-right-square-width);
-  height: var(--logo-right-square-width);
-  z-index: 50;
-  transform: rotateZ(60deg);
-}
-.core {
-  position: relative;
-  width: var(--logo-core-width);
-  height: var(--logo-core-width);
-  top: calc(var(--logo-core-width) - var(--logo-border-width) / 2);
-  margin: auto;
-  border: var(--logo-border-width) solid var(--text-color, black);
-}
-:host(.animated) .left-square,
-:host(.animated) .right-square {
-  animation: transformLeft 4s infinite linear;
-}
-@keyframes transformLeft {
-  from {
-    transform: translateX(calc(-1.467 * var(--length))) rotateZ(60deg);
-  }
-  to {
-    transform: translateX(calc(1.733 * var(--length))) rotateZ(-300deg);
-  }
-}
-`;
-
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 
 class LogoComponent extends HTMLElement {
   static get observedAttributes() {
@@ -82,13 +10,10 @@ class LogoComponent extends HTMLElement {
     const sr = this.attachShadow({
       mode: "open",
     });
-    if (canAdopt && sharedSheet) {
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./LogoComponent.css", import.meta.url).href
+    );
 
     // this.setAttribute("data-theme", getTheme()); // for iOS 15
     document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));

--- a/webcomponents/TemplateComponent.css
+++ b/webcomponents/TemplateComponent.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/webcomponents/TemplateComponent.js
+++ b/webcomponents/TemplateComponent.js
@@ -1,24 +1,5 @@
 import { handleThemeChange } from "/scripts/theme.js";
-
-const CSS = `
-:host {
-  display: block;
-}
-`;
-
-const canConstruct =
-  typeof CSSStyleSheet !== "undefined" &&
-  typeof CSSStyleSheet.prototype.replaceSync === "function";
-
-const canAdopt =
-  typeof ShadowRoot !== "undefined" &&
-  "adoptedStyleSheets" in ShadowRoot.prototype;
-
-let sharedSheet;
-if (canConstruct) {
-  sharedSheet = new CSSStyleSheet();
-  sharedSheet.replaceSync(CSS);
-}
+import { attachShadowStylesheet } from "/scripts/style-utils.js";
 
 class TemplateComponent extends HTMLElement {
   constructor() {
@@ -26,13 +7,10 @@ class TemplateComponent extends HTMLElement {
     const sr = this.attachShadow({
       mode: "open",
     });
-    if (canAdopt && sharedSheet) {
-      sr.adoptedStyleSheets = [sharedSheet];
-    } else {
-      const styleEl = document.createElement("style");
-      styleEl.textContent = CSS;
-      sr.appendChild(styleEl);
-    }
+    attachShadowStylesheet(
+      sr,
+      new URL("./TemplateComponent.css", import.meta.url).href
+    );
     // this.setAttribute("data-theme", getTheme()); 
     document.addEventListener("berry-theme", (e) => handleThemeChange(e, this));
   }


### PR DESCRIPTION
### Motivation
- Reduce inline JS-defined CSS by extracting component styles into dedicated CSS files for easier maintenance and better caching.
- Standardize how shadow-root styles are attached by using a small helper that supports preloading and prevents duplicate stylesheet inserts.

### Description
- Added `scripts/style-utils.js` which exports `attachShadowStylesheet(shadowRoot, href, { preload })` to optionally preload and append a `link rel="stylesheet"` into a shadow root while avoiding duplicates.
- Moved inline CSS out of JS and created component-scoped CSS files for `ArchivedListComponent`, `ArticleComponent`, `CodeSnippetComponent`, `DateComponent`, `FooterComponent`, `HeaderComponent`, `LogoComponent`, and `TemplateComponent`.
- Updated the corresponding component JS files to import and call `attachShadowStylesheet(...)` with `new URL("./<Component>.css", import.meta.url).href` and removed the previous constructable stylesheet / inline `<style>` fallback logic.
- Kept existing theme event handling and component logic unchanged while removing only the inline style injection code.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a9e1b4a4832b961fbe313fcc503a)